### PR TITLE
DE6964: Specify encoding when reading cve files

### DIFF
--- a/cve_lookup.py
+++ b/cve_lookup.py
@@ -23,8 +23,9 @@ def parse_dbs(folder):
     root = dict()
     header_printed = False
     for filename in glob.glob(folder + '/*.json'):
-        with open(filename) as ff:
-            cve_dict = json.loads(ff.read())
+        with open(filename, encoding='utf-8') as ff:
+            cve_dict = json.load(ff)
+
             print("Processing file " + filename)
 
             if header_printed == False:


### PR DESCRIPTION
Not sure if specifying the encoding to be `utf-8` will actually make a difference. Also split the line where we read a decode the JSON so that if it fails again we will at least know what step it's failing on.